### PR TITLE
errors in easy-rsa path

### DIFF
--- a/openvpn_paranoid_installer.sh
+++ b/openvpn_paranoid_installer.sh
@@ -206,8 +206,8 @@ else
 	# Get easy-rsa
 	wget --no-check-certificate -O ~/EasyRSA-3.0.0.tgz https://github.com/OpenVPN/easy-rsa/releases/download/3.0.0/EasyRSA-3.0.0.tgz
 	tar xzf ~/EasyRSA-3.0.0.tgz -C ~/
-	mv ~/EasyRSA-3.0.0/ /etc/openvpn/
-	mv /etc/openvpn/EasyRSA-3.0.0/ /etc/openvpn/easy-rsa/
+	mv ~/EasyRSA-3.0.0 /etc/openvpn/
+	mv /etc/openvpn/EasyRSA-3.0.0 /etc/openvpn/easy-rsa
 	chown -R root:root /etc/openvpn/easy-rsa/
 	rm -rf ~/EasyRSA-3.0.0.tgz
 	cd /etc/openvpn/easy-rsa/

--- a/openvpn_paranoid_installer.sh
+++ b/openvpn_paranoid_installer.sh
@@ -206,7 +206,8 @@ else
 	# Get easy-rsa
 	wget --no-check-certificate -O ~/EasyRSA-3.0.0.tgz https://github.com/OpenVPN/easy-rsa/releases/download/3.0.0/EasyRSA-3.0.0.tgz
 	tar xzf ~/EasyRSA-3.0.0.tgz -C ~/
-	mv ~/EasyRSA-3.0.0 /etc/openvpn/
+	mkdir /etc/openvpn
+	mv -t /etc/openvpn/ ~/EasyRSA-3.0.0
 	mv /etc/openvpn/EasyRSA-3.0.0 /etc/openvpn/easy-rsa
 	chown -R root:root /etc/openvpn/easy-rsa/
 	rm -rf ~/EasyRSA-3.0.0.tgz


### PR DESCRIPTION
there should not be closing slash, when using "mv", because it moves the contents of the folder, without creating it. so, the issue that i'm fixing was:
```bash
Saving to: ‘/root/EasyRSA-3.0.0.tgz’

/root/EasyRSA-3.0.0.tgz            100%[================================================================>]  40.00K  --.-KB/s    in 0.07s

2017-06-14 12:32:28 (568 KB/s) - ‘/root/EasyRSA-3.0.0.tgz’ saved [40960/40960]

mv: cannot stat '/etc/openvpn/EasyRSA-3.0.0/': No such file or directory
chown: cannot access '/etc/openvpn/easy-rsa/': No such file or directory
./openvpn_paranoid_installer.sh: line 213: cd: /etc/openvpn/easy-rsa/: No such file or directory
./openvpn_paranoid_installer.sh: line 215: ./easyrsa: No such file or directory
./openvpn_paranoid_installer.sh: line 216: ./easyrsa: No such file or directory
./openvpn_paranoid_installer.sh: line 217: ./easyrsa: No such file or directory
```